### PR TITLE
Ints Sequence to Uint256 

### DIFF
--- a/contracts/starknet/lib/ints_to_uint256.cairo
+++ b/contracts/starknet/lib/ints_to_uint256.cairo
@@ -1,0 +1,75 @@
+%lang starknet
+
+from starkware.cairo.common.cairo_builtins import BitwiseBuiltin
+from starkware.cairo.common.uint256 import Uint256, uint256_add, uint256_shl
+from starkware.cairo.common.math import unsigned_div_rem, assert_nn_le
+from starkware.cairo.common.math_cmp import is_le
+from starkware.cairo.common.pow import pow
+from starkware.cairo.common.bitwise import bitwise_and
+
+from starknet.types import IntsSequence
+
+const MASK_LOW = 2 ** 64
+
+func ints_to_uint256{range_check_ptr, bitwise_ptr : BitwiseBuiltin*}(
+        ints: IntsSequence) -> (res : Uint256):
+    let elements = ints.element
+    let elements_len = ints.element_size_words
+    let elements_bytes_len = ints.element_size_bytes
+    if elements_len == 1:
+        return (Uint256(elements[0],0))
+    end 
+    assert_nn_le(elements_len, 5)  # The max int sequence length for a uint256 is 4
+    let (_, rem) = unsigned_div_rem(elements_bytes_len, 8)
+    let initial : Uint256 = Uint256(elements[elements_len - 1], 0)
+    if rem == 0:
+        let (res) = ints_to_uint256_rec(elements_len - 1, elements, initial, 64)
+    else:
+        let (res) = ints_to_uint256_rec(elements_len - 1, elements, initial, rem * 8)
+    end
+    return (res)
+end
+
+func ints_to_uint256_rec{range_check_ptr, bitwise_ptr : BitwiseBuiltin*}(
+        elements_len : felt, elements : felt*, sum : Uint256, shift : felt) -> (out : Uint256): 
+    alloc_locals
+    if elements_len == 0:
+        return (sum)
+    end
+    # 3 cases:
+    # shift < 64 just add num to low
+    # 64 < shift < 128 mask bits above and below 128 and add each bit to high and low
+    # shift > 128 just add num to high
+    
+    let (case3) = is_le(128, shift)
+    if case3 == 1:
+        let (factor3) = pow(2, shift - 128) 
+        let num = elements[elements_len - 1] * factor3
+        let next : Uint256 = Uint256(low=0, high=num)
+        let (new_sum, _) = uint256_add(sum, next)
+        let (out) = ints_to_uint256_rec(elements_len - 1, elements, new_sum, shift + 64)
+    else:
+        let (local factor) = pow(2, shift)
+        let (case1) = is_le(shift, 64)
+        if case1 == 1:
+            let num = elements[elements_len - 1] * factor
+            let next : Uint256 = Uint256(num, 0)
+            let (new_sum, _) = uint256_add(sum, next)
+            let (out) = ints_to_uint256_rec(elements_len - 1, elements, new_sum, shift + 64)
+        else:
+            # case2
+            let (factor2) = pow(2, 128 - shift)
+            let mask_h = factor2 - 1
+            let (temp_l) = bitwise_and(elements[elements_len - 1], mask_h)
+            let num_l = temp_l * factor
+            let mask_l = MASK_LOW - factor2
+            let (temp_h) = bitwise_and(elements[elements_len - 1], mask_l)
+            let (num_h, _) = unsigned_div_rem(temp_h, factor2)
+            let next : Uint256 = Uint256(num_l, num_h)
+            let (new_sum, _) = uint256_add(sum, next)
+            let (out) = ints_to_uint256_rec(elements_len - 1, elements, new_sum, shift + 64)
+        end
+    end
+    return (out)
+end
+

--- a/contracts/starknet/lib/ints_to_uint256.cairo
+++ b/contracts/starknet/lib/ints_to_uint256.cairo
@@ -1,7 +1,7 @@
 %lang starknet
 
 from starkware.cairo.common.cairo_builtins import BitwiseBuiltin
-from starkware.cairo.common.uint256 import Uint256, uint256_add, uint256_shl
+from starkware.cairo.common.uint256 import Uint256, uint256_add
 from starkware.cairo.common.math import unsigned_div_rem, assert_nn_le
 from starkware.cairo.common.math_cmp import is_le
 from starkware.cairo.common.pow import pow
@@ -11,14 +11,14 @@ from starknet.types import IntsSequence
 
 const MASK_LOW = 2 ** 64
 
-func ints_to_uint256{range_check_ptr, bitwise_ptr : BitwiseBuiltin*}(
-        ints: IntsSequence) -> (res : Uint256):
+func ints_to_uint256{range_check_ptr, bitwise_ptr : BitwiseBuiltin*}(ints : IntsSequence) -> (
+        res : Uint256):
     let elements = ints.element
     let elements_len = ints.element_size_words
     let elements_bytes_len = ints.element_size_bytes
     if elements_len == 1:
-        return (Uint256(elements[0],0))
-    end 
+        return (Uint256(elements[0], 0))
+    end
     assert_nn_le(elements_len, 5)  # The max int sequence length for a uint256 is 4
     let (_, rem) = unsigned_div_rem(elements_bytes_len, 8)
     let initial : Uint256 = Uint256(elements[elements_len - 1], 0)
@@ -31,7 +31,7 @@ func ints_to_uint256{range_check_ptr, bitwise_ptr : BitwiseBuiltin*}(
 end
 
 func ints_to_uint256_rec{range_check_ptr, bitwise_ptr : BitwiseBuiltin*}(
-        elements_len : felt, elements : felt*, sum : Uint256, shift : felt) -> (out : Uint256): 
+        elements_len : felt, elements : felt*, sum : Uint256, shift : felt) -> (out : Uint256):
     alloc_locals
     if elements_len == 0:
         return (sum)
@@ -40,10 +40,10 @@ func ints_to_uint256_rec{range_check_ptr, bitwise_ptr : BitwiseBuiltin*}(
     # shift < 64 just add num to low
     # 64 < shift < 128 mask bits above and below 128 and add each bit to high and low
     # shift > 128 just add num to high
-    
+
     let (case3) = is_le(128, shift)
     if case3 == 1:
-        let (factor3) = pow(2, shift - 128) 
+        let (factor3) = pow(2, shift - 128)
         let num = elements[elements_len - 1] * factor3
         let next : Uint256 = Uint256(low=0, high=num)
         let (new_sum, _) = uint256_add(sum, next)
@@ -72,4 +72,3 @@ func ints_to_uint256_rec{range_check_ptr, bitwise_ptr : BitwiseBuiltin*}(
     end
     return (out)
 end
-

--- a/contracts/starknet/test/TestIntsToUint256.cairo
+++ b/contracts/starknet/test/TestIntsToUint256.cairo
@@ -1,0 +1,19 @@
+%lang starknet
+%builtins pedersen range_check bitwise
+
+from starkware.cairo.common.cairo_builtins import BitwiseBuiltin
+from starkware.cairo.common.uint256 import Uint256
+from starknet.types import IntsSequence 
+from starknet.lib.ints_to_uint256 import ints_to_uint256 
+
+from starkware.cairo.common.pow import pow
+from starkware.cairo.common.math import unsigned_div_rem
+from starkware.cairo.common.math_cmp import is_le
+
+@view 
+func test_ints_to_uint256{range_check_ptr, bitwise_ptr : BitwiseBuiltin*}(element_len_bytes: felt, element_len: felt, element: felt*) -> (uint256: Uint256):
+    alloc_locals
+    local input: IntsSequence = IntsSequence(element, element_len, element_len_bytes)
+    let (local out: Uint256) = ints_to_uint256(ints=input)
+    return (out)
+end

--- a/contracts/starknet/test/TestIntsToUint256.cairo
+++ b/contracts/starknet/test/TestIntsToUint256.cairo
@@ -1,19 +1,16 @@
 %lang starknet
-%builtins pedersen range_check bitwise
+%builtins range_check bitwise
 
 from starkware.cairo.common.cairo_builtins import BitwiseBuiltin
 from starkware.cairo.common.uint256 import Uint256
-from starknet.types import IntsSequence 
-from starknet.lib.ints_to_uint256 import ints_to_uint256 
+from starknet.types import IntsSequence
+from starknet.lib.ints_to_uint256 import ints_to_uint256
 
-from starkware.cairo.common.pow import pow
-from starkware.cairo.common.math import unsigned_div_rem
-from starkware.cairo.common.math_cmp import is_le
-
-@view 
-func test_ints_to_uint256{range_check_ptr, bitwise_ptr : BitwiseBuiltin*}(element_len_bytes: felt, element_len: felt, element: felt*) -> (uint256: Uint256):
+@view
+func test_ints_to_uint256{range_check_ptr, bitwise_ptr : BitwiseBuiltin*}(
+        element_len_bytes : felt, element_len : felt, element : felt*) -> (uint256 : Uint256):
     alloc_locals
-    local input: IntsSequence = IntsSequence(element, element_len, element_len_bytes)
-    let (local out: Uint256) = ints_to_uint256(ints=input)
+    local input : IntsSequence = IntsSequence(element, element_len, element_len_bytes)
+    let (local out : Uint256) = ints_to_uint256(ints=input)
     return (out)
 end

--- a/tests/lib_starknet_ints_to_uint256.py
+++ b/tests/lib_starknet_ints_to_uint256.py
@@ -1,0 +1,62 @@
+import pytest
+import asyncio
+from typing import Tuple, NamedTuple
+from random import randint
+from utils.helpers import IntsSequence, split_uint256_to_uint, uint_to_ints_array
+from starkware.starknet.testing.contract import StarknetContract
+from starkware.starknet.testing.starknet import Starknet
+
+class TestsDeps(NamedTuple):
+    starknet: Starknet
+    ints_to_uint256: StarknetContract
+
+@pytest.fixture(scope='module')
+def event_loop():
+    return asyncio.new_event_loop()
+
+async def setup():
+    starknet = await Starknet.empty()
+    ints_to_uint256 = await starknet.deploy(source="contracts/starknet/test/TestIntsToUint256.cairo", cairo_path=["contracts"])
+    return TestsDeps(
+        starknet=starknet,
+        ints_to_uint256=ints_to_uint256
+    )
+
+@pytest.fixture(scope='module')
+async def factory():
+    return await setup()
+
+@pytest.mark.asyncio 
+async def test_covert_0(factory):
+    starknet, ints_to_uint256 = factory 
+    num = 0
+    ints = uint_to_ints_array(num)
+    ints_to_uint256_call = await ints_to_uint256.test_ints_to_uint256(ints.length,ints.values).call()
+    assert split_uint256_to_uint(ints_to_uint256_call.result.uint256) == num
+
+@pytest.mark.asyncio 
+async def test_covert_1(factory):
+    starknet, ints_to_uint256 = factory 
+    num = 1
+    ints = uint_to_ints_array(num)
+    ints_to_uint256_call = await ints_to_uint256.test_ints_to_uint256(ints.length,ints.values).call()
+    assert split_uint256_to_uint(ints_to_uint256_call.result.uint256) == num
+
+@pytest.mark.asyncio 
+async def test_covert_random(factory):
+    starknet, ints_to_uint256 = factory 
+    num = randint(0, (2**256) - 1)
+    ints = uint_to_ints_array(num)
+    print(ints)
+    ints_to_uint256_call = await ints_to_uint256.test_ints_to_uint256(ints.length,ints.values).call()
+    assert split_uint256_to_uint(ints_to_uint256_call.result.uint256) == num
+
+    print(f"ints_to_uint256_call n_steps: {ints_to_uint256_call.call_info.cairo_usage.n_steps}")
+
+@pytest.mark.asyncio 
+async def test_covert_out_of_bound_uint(factory):
+    starknet, ints_to_uint256 = factory 
+    num = randint(2**256, 2**512) 
+    ints = uint_to_ints_array(num)
+    with pytest.raises(Exception):
+        await ints_to_uint256.test_ints_to_uint256(ints.length,ints.values).call()

--- a/tests/lib_starknet_ints_to_uint256.py
+++ b/tests/lib_starknet_ints_to_uint256.py
@@ -47,11 +47,8 @@ async def test_covert_random(factory):
     starknet, ints_to_uint256 = factory 
     num = randint(0, (2**256) - 1)
     ints = uint_to_ints_array(num)
-    print(ints)
     ints_to_uint256_call = await ints_to_uint256.test_ints_to_uint256(ints.length,ints.values).call()
     assert split_uint256_to_uint(ints_to_uint256_call.result.uint256) == num
-
-    print(f"ints_to_uint256_call n_steps: {ints_to_uint256_call.call_info.cairo_usage.n_steps}")
 
 @pytest.mark.asyncio 
 async def test_covert_out_of_bound(factory):

--- a/tests/lib_starknet_ints_to_uint256.py
+++ b/tests/lib_starknet_ints_to_uint256.py
@@ -54,7 +54,7 @@ async def test_covert_random(factory):
     print(f"ints_to_uint256_call n_steps: {ints_to_uint256_call.call_info.cairo_usage.n_steps}")
 
 @pytest.mark.asyncio 
-async def test_covert_out_of_bound_uint(factory):
+async def test_covert_out_of_bound(factory):
     starknet, ints_to_uint256 = factory 
     num = randint(2**256, 2**512) 
     ints = uint_to_ints_array(num)

--- a/tests/utils/helpers.py
+++ b/tests/utils/helpers.py
@@ -15,9 +15,7 @@ class Encoding(Enum):
     LITTLE: str = 'little'
     BIG: str = 'big'
 
-
 concat_arr: Callable[[List[str]], str] = lambda arr: reduce(lambda a, b: a + b, arr)
-
 
 def bytes_to_int(word: bytes, encoding: Encoding = Encoding.BIG) -> int:
     return int.from_bytes(word, encoding.value)
@@ -31,7 +29,6 @@ string_to_byte_big: Callable[[str], int] = lambda word: int.from_bytes(word.enco
 hex_string_little_to_int: Callable[[HexStr], int] = lambda word: bytes_to_int_little(bytes.fromhex(word))
 hex_string_big_to_int: Callable[[HexStr], int] = lambda word: bytes_to_int_big(bytes.fromhex(word))
 
-
 chunk_bytes_input: Callable[[bytes], List[bytes]] = lambda input: [input[i+0:i+8] for i in range(0, len(input), 8)]
 
 print_bytes_array: Callable[[List[str]], str] = lambda arr: concat_arr(list(map(lambda a: a.hex()+'\n', arr)))
@@ -42,9 +39,18 @@ def hex_string_to_words64(hex_input: str, encoding: Encoding = Encoding.BIG) -> 
         raise Exception('Rlp string to short')
     prefix = hex_input[0:2]
     if prefix == '0x': hex_input = hex_input[2:]
-
+    if len(hex_input)%2==1: hex_input = '0'+hex_input
     chunked = [hex_input[i+0:i+16] for i in range(0, len(hex_input), 16)]
     return IntsSequence(list(map(hex_string_big_to_int if encoding == Encoding.BIG else hex_string_little_to_int, chunked)), int(len(hex_input)/2))
+
+# def hex_string_to_words64(hex_input: str, encoding: Encoding = Encoding.BIG) -> IntsSequence:
+#     if len(hex_input) < 2:
+#         raise Exception('Rlp string to short')
+#     prefix = hex_input[0:2]
+#     if prefix == '0x': hex_input = hex_input[2:]
+
+#     chunked = [hex_input[i+0:i+16] for i in range(0, len(hex_input), 16)]
+#     return IntsSequence(list(map(hex_string_big_to_int if encoding == Encoding.BIG else hex_string_little_to_int, chunked)), int(len(hex_input)/2))
 
 def hex_string_to_nibbles(hex_input: str, encoding: Encoding = Encoding.BIG) -> List[int]:
     if len(hex_input) < 2:
@@ -123,3 +129,9 @@ def keccak_words64(input: IntsSequence) -> IntsSequence:
 
 def compare_lists(a: List[Any], b: List[Any]):
     return reduce(lambda i, j : i and j, map(lambda m, k: m == k, a, b), True)
+
+def split_uint256_to_uint(split_uint256: Tuple):
+    return split_uint256[0] + (split_uint256[1] << 128)
+
+def uint_to_ints_array(uint) -> IntsSequence:
+    return hex_string_to_words64(hex(uint))

--- a/tests/utils/helpers.py
+++ b/tests/utils/helpers.py
@@ -43,15 +43,6 @@ def hex_string_to_words64(hex_input: str, encoding: Encoding = Encoding.BIG) -> 
     chunked = [hex_input[i+0:i+16] for i in range(0, len(hex_input), 16)]
     return IntsSequence(list(map(hex_string_big_to_int if encoding == Encoding.BIG else hex_string_little_to_int, chunked)), int(len(hex_input)/2))
 
-# def hex_string_to_words64(hex_input: str, encoding: Encoding = Encoding.BIG) -> IntsSequence:
-#     if len(hex_input) < 2:
-#         raise Exception('Rlp string to short')
-#     prefix = hex_input[0:2]
-#     if prefix == '0x': hex_input = hex_input[2:]
-
-#     chunked = [hex_input[i+0:i+16] for i in range(0, len(hex_input), 16)]
-#     return IntsSequence(list(map(hex_string_big_to_int if encoding == Encoding.BIG else hex_string_little_to_int, chunked)), int(len(hex_input)/2))
-
 def hex_string_to_nibbles(hex_input: str, encoding: Encoding = Encoding.BIG) -> List[int]:
     if len(hex_input) < 2:
         raise Exception('Hex string to short')


### PR DESCRIPTION
- Added a library function to convert the `IntsSequence` type to the cairo `Uint256`, along with a test contract and script for it. 
- Added two helper functions `split_uint256_to_uint` and `uint_to_ints_array` to the `tests/utils/helpers.py` file which are used in the test script. 
- Modified the `hex_string_to_words64` helper function to take odd length hex strings. 